### PR TITLE
Add notebook demonstrating Codex API call

### DIFF
--- a/codex_api_call.ipynb
+++ b/codex_api_call.ipynb
@@ -1,0 +1,33 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openai import OpenAI\n",
+    "client = OpenAI(base_url=\"xxxxx\", api_key=\"xxxxx\")\n",
+    "out = client.chat.completions.create(\n",
+    "    model=\"gpt-oss-20b\",\n",
+    "    messages=[{\"role\":\"user\",\"content\":\"model version\"}],\n",
+    "    temperature=0.2,\n",
+    ")\n",
+    "print(out.choices[0].message.content)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a new Jupyter notebook that demonstrates calling the Codex-compatible `gpt-oss-20b` model using the OpenAI SDK

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbb83c438c832e980133598102a5a6